### PR TITLE
Edited default time zone and started some on timezone work

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ south
 markdown2
 fabric
 simplejson
+pytz

--- a/wikipendium/settings/base.py
+++ b/wikipendium/settings/base.py
@@ -13,7 +13,9 @@ MANAGERS = ADMINS
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = 'America/Chicago'
+TIME_ZONE = 'Europe/Oslo'
+
+USE_TZ = True
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
@@ -112,6 +114,7 @@ INSTALLED_APPS = (
     'south',
 
     'wikipendium.wiki',
+    'pytz',
 )
 
 


### PR DESCRIPTION
As timezones were harder to implement as of now, due to little user configuration, the default timezone was changed to reflect a zone used by the devs. In addition, pytz was installed and added as a requirement, as it will be used with timezones. 

This updates [#93](https://github.com/stianjensen/wikipendium.no/issues/93).
