### PR TITLE
Improved diff rendering

### DIFF
--- a/wikipendium/wiki/diff.py
+++ b/wikipendium/wiki/diff.py
@@ -26,7 +26,7 @@ def textDiff(a, b):
 		elif e[0] == "insert":
 			out.append('<ins class="diff">'+''.join(b[e[3]:e[4]]) + "</ins>")
 		elif e[0] == "equal":
-			out.append(''.join(b[e[3]:e[4]]))
+			out.append('<span class="diff equal hidden">' + ''.join(b[e[3]:e[4]]) + '</span>')
 		else: 
 			raise "Um, something's broken. I didn't expect a '" + `e[0]` + "'."
 	return ''.join(out)

--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -2341,6 +2341,7 @@ del{
 ins{
     background: lightgreen;
     display: inline-block;
+    text-decoration: none;
 }
 .article-history-list {
     list-style-type: none;
@@ -2371,6 +2372,31 @@ ins{
     border-radius:10px;
     margin: 0 0 30px 0;
     margin-top:50px;
+}
+
+.article-source{
+    font-family: monospace;
+    white-space: pre-wrap;
+}
+
+.diff.equal{
+    cursor:pointer;
+}
+
+.diff.equal:hover{
+    opacity: 1 !important;
+}
+
+.diff.equal.hidden{
+    height: 1.3em;
+    overflow:hidden;
+    text-overflow: ellipsis;
+    display:inline-block;
+    opacity: 0.5;
+}
+
+.diff.equal.hidden:before{
+    content: "... ";
 }
 
 /********************

--- a/wikipendium/wiki/templates/base.html
+++ b/wikipendium/wiki/templates/base.html
@@ -4,7 +4,9 @@
 <head>
     <title>{% block title %}{% endblock %} Wikipendium</title>
     <script src=//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.0/jquery.min.js></script>
+    {% if mathjax %}
     <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    {% endif %}
     <link rel=stylesheet href={{STATIC_URL}}css/master.css />
     <script src={{STATIC_URL}}js/bootstrap.min.js></script>
     <script src={{STATIC_URL}}epiceditor/js/epiceditor.js></script>
@@ -19,6 +21,7 @@
     <link rel="apple-touch-icon" href="{{STATIC_URL}}apple-touch/icon-114x114.png" sizes="114x114" />
     <link rel="shortcut icon" href="{{STATIC_URL}}images/favicon.png" />
 
+    {% if mathjax %}
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({
   tex2jax: {
@@ -27,6 +30,7 @@ MathJax.Hub.Config({
   }
 });
 </script>
+{% endif %}
 
     <script>
         

--- a/wikipendium/wiki/templates/history_single.html
+++ b/wikipendium/wiki/templates/history_single.html
@@ -24,8 +24,17 @@
 {% endif %}
 </div>
 
-<div id=article class=serif>
+<div id=article class=article-source>
     <h1 class=title>{{ ac.get_full_title }}</h1>
     <div class=content>{{ ac.diff|safe }}</div>
 </div>
+
+<script>
+    $(function(){
+        $('.diff.equal').click(function(){
+            $(this).toggleClass('hidden'); 
+        });
+    });
+</script>
+
 {% endblock %}

--- a/wikipendium/wiki/views.py
+++ b/wikipendium/wiki/views.py
@@ -81,6 +81,7 @@ def article(request, slug, lang="en"):
     available_languages = article.get_available_languages(articleContent)
 
     return render(request, 'article.html', {
+        "mathjax": True,
         "content": content['html'],
         "toc": (content['toc'] or "").replace('<ul>','<ol>').replace('</ul>','</ol>'),
         "articleContent": articleContent,
@@ -152,8 +153,8 @@ def history_single(request, slug, lang, id):
     ac = ArticleContent.objects.get(id=id)
 
     ac.diff = diff.textDiff(
-        ac.parent.get_html_content()['html'] if ac.parent else '',
-        ac.get_html_content()['html']
+        ac.parent.content if ac.parent else '',
+        ac.content
     )
 
     originalArticle = article.get_newest_content(lang=lang)


### PR DESCRIPTION
This improves rendering of a single article history diff. Features are:
- togglably collapsed rendering of unchanged areas
- no more ugly underlines in <ins>-tags
- togglable mathjax rendering, use "mathjax": True in a template's context to enable mathjax
- diff is now on article markdown/LaTeX source, not on the outputted HTML.

![image](https://f.cloud.github.com/assets/578029/601658/8d7758e4-cc85-11e2-9e0d-4061ce6a7241.png)
A diff with some changes and a collapsed area.

![image](https://f.cloud.github.com/assets/578029/601662/b1bcff4c-cc85-11e2-9a5e-42c488fdb0a2.png)
The same diff with the middle area expanded.

This fixes #43 and #53.
