### PR TITLE
Fix bug where wrong username is sometimes printed in header

### DIFF
--- a/wikipendium/wiki/templates/base.html
+++ b/wikipendium/wiki/templates/base.html
@@ -98,7 +98,7 @@ MathJax.Hub.Config({
                     {% if user.is_authenticated %}
         
     <div class="has-dropdown button-dropdown">
-        <a href=# class=button data-toggle=dropdown><i class="icon icon-prepend green-bg"></i>{{user.username}}<span class=caret></span></a>
+        <a href=# class=button data-toggle=dropdown><i class="icon icon-prepend green-bg"></i>{{request.user.username}}<span class=caret></span></a>
         <ul class="dropdown right">
             <li><a href=/users/{{request.user.username}}/>Profile</a></li>
             <li><a href=/accounts/password/change/>Change password</a></li>


### PR DESCRIPTION
When viewing another users profile, the username printed in the header is not your own, but the one of the profile you are currently visiting. This fixes that.
![image](https://f.cloud.github.com/assets/1413267/605531/c14053ea-cd18-11e2-82af-82ce1f31fc24.png)
