### PR TITLE
Update article layout

### DIFF
--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -2165,18 +2165,6 @@ h1,h2,h3,h4,h5,h6{
     margin: 20px 0;
     font-size: .9em;
     line-height: 1.4;
-    border: 1px solid #999;
-    background: #fafafa;
-    max-height: 350px;
-    overflow: auto;
-
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    border-radius: 5px;
-
-    -webkit-box-shadow: inset 0 5px 6px -5px;
-    -moz-box-shadow: inset 0 5px 6px -5px;
-    box-shadow: inset 0 5px 6px -5px;
 }
 #toc h3 {
     margin: .5em 0;


### PR DESCRIPTION
Turning up the font size slightly so it's easier to read. Also expanding the max-width slightly to maintain letters per length ratio.

This also fixes a bug where when you clicked on links in the table of contents the page would scroll to the heading, but it would be placed underneath the header.

Closes #54
