### PR TITLE
Fix crash when creating compendium with new slug

### DIFF
--- a/wikipendium/wiki/models.py
+++ b/wikipendium/wiki/models.py
@@ -64,7 +64,7 @@ class Article(models.Model):
 
     def get_available_languages(self, current=None):
         codes = self.get_available_language_codes()
-        if current and current.lang is not None:
+        if current and current.lang is not None and current.lang in codes:
             codes.remove(current.lang)
         if codes:
             return zip(map(lambda key: LANGUAGE_NAMES[key], codes),


### PR DESCRIPTION
You got an error if you navigated to an unused slug, or when using the search field on the front page, and pressing enter when no match was found.
