### PR TITLE
Fix caret offset in editor

### DIFF
--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -2211,6 +2211,12 @@ pre code {
     border-radius: 2px;
 }
 
+.CodeMirror pre {
+    white-space: pre-wrap;
+    word-break: break-all;
+    word-wrap: break-word;
+}
+
 form .fields.slug-field {
     width:11%;
     float:left;


### PR DESCRIPTION
In CodeMirror, when lines are so long that they wrap, the caret would be displayed one column to the left of where it actually was.
