### PR TITLE
Freeze package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 django==1.4
-django-registration
-south
-markdown2
-fabric
-pytz
-markdown2Mathjax
-django-ignoretests
-boto
+django-registration==1.0
+south==0.8.1
+markdown2==2.1.0
+fabric==1.7.0
+pytz==2013b
+markdown2Mathjax==0.3.8
+django-ignoretests==0.3.2
+boto==2.9.9


### PR DESCRIPTION
The prod server already has the newest version of the packages we are currently using. This is because we haven't specified which version we want to use, so it always just grabs the newest one it can find. Thankfully, this hasn't bitten us in the ass.

But that doesn't mean it won't, and the package versions will now be frozen at the versions currently active in prod. This means that from now on, we have to keep an eye on updates for our packages, and update them manually _(by editing requirements.txt)_ when new versions are available.

For instance, Django 1.5 has been out for a while, and I intend to update it in the coming days, so we're not lagging too much behind when 1.6 is released in the coming months.
