### PR TITLE
Fix crash when a field is not filled out

### DIFF
--- a/wikipendium/wiki/forms.py
+++ b/wikipendium/wiki/forms.py
@@ -22,6 +22,10 @@ class ArticleForm(ModelForm):
         super(ArticleForm, self).__init__(*args, **kwargs)
         self.fields['slug'].widget.attrs['placeholder'] = 'Course code'
         self.fields['pk'].widget.attrs['value'] = 0
+        self.fields['lang'].widget.attrs = {
+            'class': "select_chosen",
+            'data-placeholder': "Language"
+        }
 
         try:
             if self.instance.article:
@@ -42,11 +46,6 @@ class ArticleForm(ModelForm):
                     self.fields['lang'].widget = forms.TextInput(attrs={
                         'readonly': True
                     })
-                else:
-                    self.fields['lang'].widget.attrs = {
-                        'class': "select_chosen",
-                        'data-placeholder': "Language"
-                    }
         except:
             pass
 
@@ -55,7 +54,8 @@ class ArticleForm(ModelForm):
 
     def clean(self):
         super(ArticleForm, self)
-        self.merge_contents_if_needed()
+        if 'slug' in self.cleaned_data and 'lang' in self.cleaned_data:
+            self.merge_contents_if_needed()
         return self.cleaned_data
 
     def merge_contents_if_needed(self):

--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -2261,6 +2261,9 @@ form .fields.title-field input {
     font-size: 1.4em;
     font-weight: bold;
 }
+form .fields.error {
+    margin-bottom: 25px;
+}
 
 form .field-group.content-field {
     clear: both;

--- a/wikipendium/wiki/views.py
+++ b/wikipendium/wiki/views.py
@@ -148,16 +148,17 @@ def edit(request, slug, lang='en'):
             return HttpResponseRedirect(new_articleContent.get_absolute_url())
     else:
         form = ArticleForm(instance=articleContent)
-        available_languages = article.get_available_languages(articleContent)
-        language_list = map(lambda x: (x[0], x[1].get_edit_url),
-                            available_languages or [])
 
-        return render(request, 'edit.html', {
-            "mathjax": True,
-            "language_list": language_list,
-            "articleContent": articleContent,
-            "form": form
-        })
+    available_languages = article.get_available_languages(articleContent)
+    language_list = map(lambda x: (x[0], x[1].get_edit_url),
+                        available_languages or [])
+
+    return render(request, 'edit.html', {
+        "mathjax": True,
+        "language_list": language_list,
+        "articleContent": articleContent,
+        "form": form
+    })
 
 
 def history(request, slug, lang="en"):


### PR DESCRIPTION
Stops the server from returning 502 if a user skips filling out a field when editing/creating an article.

Closes #158 
