### PR TITLE
Show 404 page when no user can be found

### DIFF
--- a/wikipendium/wiki/templates/404.html
+++ b/wikipendium/wiki/templates/404.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block title %}Page not found -{% endblock %}
+
+{% block body_class %}article{% endblock %}
+
+{% block content %}
+<div id=article class=serif>
+    <h1 class=title>Page not found</h1>
+</div>
+{% endblock %}

--- a/wikipendium/wiki/views.py
+++ b/wikipendium/wiki/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, Http404
 from django.utils import simplejson
 from django.contrib.auth.decorators import login_required
 from wikipendium.wiki.models import Article, ArticleContent
@@ -194,7 +194,11 @@ def history_single(request, slug, lang, id):
 
 
 def user(request, username):
-    user = User.objects.get(username=username)
+    try:
+        user = User.objects.get(username=username)
+    except User.DoesNotExist:
+        raise Http404
+
     contributions = ArticleContent.objects.filter(
         edited_by=user).order_by('-updated')
 


### PR DESCRIPTION
closes #96 

It can definitely use more styling, or something fun, as a good 404 site should have. I still think this is better than 502 ^^

To test locally, and not see the standard django Page Not Found, you have to set `DEBUG = False`. This might render a 500 error. In that case, add `ALLOWED_HOSTS = ['localhost']` to your local.py.
For extra fun this will cause all static files to fail loading, so you only actually get a preview of the html.
I guess one way around this is setting up a temporary custom view that renders the 404.html template.
