### PR TITLE
Fix newrelic errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytz==2013d
 markdown2Mathjax==0.3.8
 django-ignoretests==0.3.2
 boto==2.9.9
+newrelic==2.0.0.1

--- a/wikipendium/settings/local.py.example
+++ b/wikipendium/settings/local.py.example
@@ -29,3 +29,9 @@ AWS_ID = ''
 AWS_KEY = ''
 AWS_BUCKET_NAME = ''
 """
+
+# For newrelic integration
+"""
+import newrelic.agent
+newrelic.agent.initialize('/home/prods/wikipendium.no/wikipendium/settings/newrelic.ini')
+"""

--- a/wikipendium/wsgi.py
+++ b/wikipendium/wsgi.py
@@ -17,12 +17,6 @@ import os
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wikipendium.settings")
 
-try:
-    import newrelic.agent
-    newrelic.agent.initialize('wikipendium/settings/newrelic.ini')
-except:
-    pass
-
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.


### PR DESCRIPTION
Putting newrelic loading back to local.py seems to be the best thing to do.
