### PR TITLE
Include allowed_hosts django 1.5 requirement in local dev setups

### DIFF
--- a/wikipendium/settings/local.py.example
+++ b/wikipendium/settings/local.py.example
@@ -1,6 +1,8 @@
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
+ALLOWED_HOSTS = ['localhost']
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.


### PR DESCRIPTION
Needed for whenever you're running with `DEBUG = False`
