### PR TITLE
Disallow subpages for bots

### DIFF
--- a/wikipendium/wiki/static/robots.txt
+++ b/wikipendium/wiki/static/robots.txt
@@ -1,2 +1,5 @@
 User-agent: *
 Disallow: /admin/
+Disallow: /*/history/
+Disallow: /*/edit/
+Disallow: /*/add_language/


### PR DESCRIPTION
This syntax is not valid according to the official robots.txt spec, but should be interpreted correctly by most current bots.
