### PR TITLE
History displays proper 404

### DIFF
--- a/wikipendium/wiki/views.py
+++ b/wikipendium/wiki/views.py
@@ -161,7 +161,11 @@ def edit(request, slug, lang='en'):
 
 
 def history(request, slug, lang="en"):
-    article = Article.objects.get(slug=slug)
+    try:
+        article = Article.objects.get(slug=slug)
+    except:
+        return no_article(request, slug.upper(), lang)
+
     articleContents = article.get_sorted_contents(lang=lang)
 
     originalArticle = article.get_newest_content(lang=lang)


### PR DESCRIPTION
When no article is found in the history view, a proper 404 message is
shown instead of the previous inbox-spamming meltdown.
