### PR TITLE
Add slash to the line-numbered edit buttons

### DIFF
--- a/wikipendium/wiki/static/js/script.js
+++ b/wikipendium/wiki/static/js/script.js
@@ -102,7 +102,7 @@ $(function(){
 
     $('[data-source-line-number]').each(function(i, el){
         var a = $('<a class="edit-section-button button">Edit</a>');
-        a.attr('href',window.location.pathname + '/edit#' + $(el).attr('data-source-line-number'));
+        a.attr('href',window.location.pathname + '/edit/#' + $(el).attr('data-source-line-number'));
         $(el).prepend(a);
 
         var semaphor = 0;


### PR DESCRIPTION
The edit URL on the edit buttons on each headline in a compendium has no slash before the hash symbol.
As the edit URL ends with a slash, browsers redirect to a URL with the slash.

In safari this redirection causes the hash part of the URL to disappear.

This fix avoids the redirect by adding a slash to the edit URLs.
