### PR TITLE
Tell Google Analytics user is still on page

### DIFF
--- a/wikipendium/wiki/templates/base.html
+++ b/wikipendium/wiki/templates/base.html
@@ -107,6 +107,11 @@
 
   ga('create', '{{GOOGLE_ANALYTICS_KEY}}', '{{GOOGLE_ANALYTICS_NAME}}');
   ga('send', 'pageview');
+
+  var fiveMinInMs = 5 * 60 * 1000;
+  setInterval(function() {
+    ga('send', 'event', 'still-on-page');
+  }, fiveMinInMs);
 </script>
 {% endif %}
 


### PR DESCRIPTION
This commit tells google analytics every five minutes that a person
still is on the page. This will help us have better numbers from GA.
