### PR TITLE
Organise profile contributions by article

### DIFF
--- a/wikipendium/wiki/models.py
+++ b/wikipendium/wiki/models.py
@@ -124,6 +124,9 @@ class ArticleContent(models.Model):
     def get_full_title(self):
         return self.article.slug + ': ' + self.title
 
+    def get_last_descendant(self):
+        return self.article.get_newest_content(lang=self.lang)
+
     def get_absolute_url(self):
         lang = ""
         if self.lang != "en":

--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -2398,7 +2398,7 @@ ins{
 .article-history-list {
     list-style-type: none;
     margin: 0;
-    margin-top:50px;
+    margin-bottom: 50px;
 }
 .article-history-list li {
     padding: .5em;
@@ -2415,6 +2415,17 @@ ins{
 .article-history-list a {
     padding-left: .5em;
     float: left;
+}
+
+.article-history-list .click-to-expand {
+    cursor: pointer;
+}
+.article-history-list .dropdown-marker {
+    float: right;
+}
+
+.contributions-title {
+    margin: 50px 0 25px;
 }
 
 .info{

--- a/wikipendium/wiki/templates/user.html
+++ b/wikipendium/wiki/templates/user.html
@@ -15,16 +15,34 @@
             <img src="{{ gravatar }}" width=150 height=150 />
         </div>
         {% endif %}
-        <h1 class=title>{{ user }}</h1>
+        <h2 class=title>{{ user }}</h2>
    </div>
-   <h3>Contributions:</h3>
+   <h3 class=contributions-title>Contributions:</h3>
     <ul class=article-history-list>
-        {% for ac in contributions %}
-        <li class="clearfix">
-            <a href="{{ac.get_history_single_url}}">{{ ac.get_full_title }}</a>
-            <span class="date">{{ ac.updated }}</span>
-        </li>
+        {% for _, acs in contributions %}
+            <li class="clearfix click-to-expand">
+            <span class=dropdown-marker>▼</span>
+            <a href={{ acs.0.get_last_descendant.get_absolute_url }}>
+            {{ acs.0.get_last_descendant.get_full_title }}</a>
+            </li>
+
+            <ul class="article-history-list hide">
+            {% for ac in acs %}
+            <li class="clearfix">
+            <a href="{{ ac.get_history_single_url }}">Changeset #{{ ac.pk }}</a>
+                <span class="date">{{ ac.updated }}</span>
+            </li>
+            {% endfor %}
+            </ul>
         {% endfor %}
     </ul>
 </div>
+<script>
+    $(function(){
+        $('.click-to-expand').click(function(){
+            console.log($(this).next());
+            $(this).next().toggle();
+        });
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
The profile of people with many contributions looked messy. This commit
tries to remedy this by grouping article contributions by article, and
hiding everything but the article name by default.

This fixes #209.

![image](https://cloud.githubusercontent.com/assets/578029/2877725/1837a19e-d452-11e3-85d9-152a051df205.png)
