### PR TITLE
Redirect article to correct language

### DIFF
--- a/wikipendium/wiki/views.py
+++ b/wikipendium/wiki/views.py
@@ -41,7 +41,7 @@ def article(request, slug, lang="en"):
     try:
         article = Article.objects.get(slug=slug.upper())
     except:
-        return no_article(request, slug.upper(), lang)
+        return no_article(request, slug.upper())
 
     articleContent = article.get_newest_content(lang)
     if articleContent is None:
@@ -67,12 +67,10 @@ def article(request, slug, lang="en"):
         "articleContent": articleContent,
         "language_list": language_list,
         'contributors': contributors,
-        "share_url": "http://" + request.META['HTTP_HOST'] +
-        request.get_full_path(),
     })
 
 
-def no_article(request, slug, lang="en"):
+def no_article(request, slug):
     create_url = "/" + slug + "/add_language/"
     return render(request, 'no_article.html', {
         "slug": slug,


### PR DESCRIPTION
Today, a user that goes to wikipendium.no/TEP4105 will be presented
with the missing language screen, as the compendium only exist in
norwegian.
This makes the use of short URLs to compendiums impractical.

With this pull request, if the requested language version doesn't exist,
the user will be redirected a version that does exist, if there is only
one language version of the article.

If there exist multiple, the user will still be presented
with the existing 'missing language' page.

Closes #220
