### PR TITLE
Sort search results by relevance

### DIFF
--- a/wikipendium/wiki/static/js/autocompletrie.js
+++ b/wikipendium/wiki/static/js/autocompletrie.js
@@ -17,6 +17,21 @@
                         ret.push(trie[i]);
                     }
                 }
+
+                function heuristic(element){
+                    return element.label.toLowerCase().split(' ').map(
+                        function(substring){
+                            return substring.indexOf(word);
+                        }
+                    ).reduce(function(a, b){
+                        return a + b;
+                    }, 0) + element.label.toLowerCase().indexOf(word);
+                }
+
+                ret.sort(function(a, b){
+                    return heuristic(a) - heuristic(b);
+                });
+
                 return ret;
             }
 


### PR DESCRIPTION
Relevance is decided as a function of how early in the course title the
search term is, as well as how early in each of the words of the course
title the search term is.

This fixes #234.
