### PR TITLE
Fix mathjax extensions typo

### DIFF
--- a/wikipendium/wiki/templates/base.html
+++ b/wikipendium/wiki/templates/base.html
@@ -42,7 +42,7 @@
     <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
       TeX: {
-        extensions: ['AMSMath.js', 'AMSSymbols.js']
+        extensions: ['AMSmath.js', 'AMSsymbols.js']
       },
       tex2jax: {
         inlineMath: [['$','$'], ['\\(','\\)']],


### PR DESCRIPTION
Both extensions failed to load due to a typo
