### PR TITLE
Disable caching of redirects in article view

### DIFF
--- a/wikipendium/wiki/views.py
+++ b/wikipendium/wiki/views.py
@@ -38,18 +38,18 @@ def article(request, slug, lang="en"):
 
     articleContent = article.get_newest_content(lang)
 
+    if articleContent is None:
+        language_codes = article.get_available_language_codes()
+        if len(language_codes) == 1:
+            new_lang = language_codes[0]
+            return HttpResponseRedirect(article.get_absolute_url(new_lang))
+        return missing_language(request, article, lang)
+
+    if request.path != article.get_absolute_url(lang):
+        return HttpResponseRedirect(article.get_absolute_url(lang))
+
     @cache_page_per_user
     def cachable_article(request, articleContent, lang=lang):
-        if articleContent is None:
-            language_codes = article.get_available_language_codes()
-            if len(language_codes) == 1:
-                new_lang = language_codes[0]
-                return HttpResponseRedirect(article.get_absolute_url(new_lang))
-            return missing_language(request, article, lang)
-
-        if request.path != article.get_absolute_url(lang):
-            return HttpResponseRedirect(article.get_absolute_url(lang))
-
         contributors = articleContent.get_contributors()
 
         content = articleContent.get_html_content()


### PR DESCRIPTION
That turned out to be a bad idea.

If a user first goes to the URL wikipendium.no/tdt4258,
the cache will remember that the view for the article tdt4258
should always redirect to wikipendium.no/TDT4258_Energy...

Since the actual path is not part of the cache key, this causes a
redirect loop.
