### PR TITLE
Remove placeholder transition timeout

### DIFF
--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -1074,18 +1074,10 @@ input.char10 {
 
 ::-webkit-input-placeholder {
   color: #999999;
-  -webkit-transition: 0.2s all;
-  -moz-transition: 0.2s all;
-  -o-transition: 0.2s all;
-  transition: 0.2s all;
 }
 
 :-moz-placeholder {
   color: #999999;
-  -webkit-transition: 0.2s all;
-  -moz-transition: 0.2s all;
-  -o-transition: 0.2s all;
-  transition: 0.2s all;
 }
 
 ::-webkit-input-placeholder:focus {


### PR DESCRIPTION
This removes the annoying placeholder text collision bug in input
fields. Helium CSS is the worst.
