### PR TITLE
Make python-markdown-mathjax escape dollar signs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ django==1.6.4
 git+git://github.com/macropin/django-registration.git@e3ec641fc0#egg=django-registration-fix
 south==0.8.2
 git+git://github.com/sigvef/Python-Markdown.git#egg=markdown
-git+git://github.com/sigvef/python-markdown-mathjax.git#egg=mdx_mathjax
+git+git://github.com/wikipendium/python-markdown-mathjax.git#egg=markdown_mathjax
 git+git://github.com/stianjensen/mdx_outline.git
 fabric==1.8.0
 pytz==2013d

--- a/wikipendium/wiki/templates/base.html
+++ b/wikipendium/wiki/templates/base.html
@@ -49,7 +49,8 @@
       },
       tex2jax: {
         inlineMath: [['$','$'], ['\\(','\\)']],
-        displayMath: [['$$','$$'], ['\\[','\\]']]
+        displayMath: [['$$','$$'], ['\\[','\\]']],
+        processEscapes: true
       },
       "HTML-CSS": {
         linebreaks: {automatic: true, width: "container"}


### PR DESCRIPTION
The old version didn't really do a very impressive job of it.

Also, tell mathjax that there might be some incoming escaped dollar
signs.
