### PR TITLE
Change event handler syntax for beforeunload

### DIFF
--- a/wikipendium/wiki/static/js/script.js
+++ b/wikipendium/wiki/static/js/script.js
@@ -85,13 +85,13 @@ $(function(){
         }
     });
 
-    window.addEventListener('beforeunload', function(){
+    window.onbeforeunload = function(e) {
         if (editor_has_been_updated) {
             return "You have unsaved changes!";
         }
-    });
+    };
 
-    
+
     $('#help-tabs a').click(function (e) {
         e.preventDefault();
         $(this).tab('show');


### PR DESCRIPTION
Apparently this is the only syntax that will reliably show the warning
message.
