### PR TITLE
Adapt definition lists for mobile layout

### DIFF
--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -852,6 +852,7 @@ ol {
 dl {
   margin: 0 0 14px;
   overflow: hidden;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.13);
 }
 
 dt {
@@ -871,6 +872,17 @@ dd {
   margin: 0;
   padding: 5px;
   border-top: 1px solid rgba(0, 0, 0, 0.13);
+}
+
+@media all and (max-width: 500px) {
+    dt, dd {
+        float: none;
+        width: auto;
+        padding: 5px 0;
+    }
+    dd {
+        border-top: none;
+    }
 }
 
 table {


### PR DESCRIPTION
This makes definition lists much better than tables in many cases, as they are able to reflow into a one-column layout when little width is available.