### PR TITLE
Update mathjax URL to official CDN

### DIFF
--- a/wikipendium/wiki/templates/base.html
+++ b/wikipendium/wiki/templates/base.html
@@ -57,7 +57,7 @@
       }
     });
     </script>
-    <script type="text/javascript" src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     {% endif %}
 </head>
 


### PR DESCRIPTION
MathJax 2.4 is released, but we're using some unofficial CDN URL, which
still doesn't provide the newest release.

This has caused some issues with loading math in some browsers.
