### PR TITLE
Update python-markdown to wikipendium-hosted fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django==1.7.3
 django-registration-redux==1.1
-git+git://github.com/sigvef/Python-Markdown.git#egg=markdown
+git+git://github.com/wikipendium/Python-Markdown.git@5e9e809#egg=markdown
 git+git://github.com/wikipendium/python-markdown-mathjax.git#egg=markdown_mathjax
 git+git://github.com/stianjensen/mdx_outline.git
 fabric==1.8.0


### PR DESCRIPTION
The new fork includes a fix for incorrect parsing of headers in source-links.