### PR TITLE
Add absolute url override for user

### DIFF
--- a/wikipendium/settings/base.py
+++ b/wikipendium/settings/base.py
@@ -192,3 +192,5 @@ CACHES = {
 }
 
 SESSION_COOKIE_SECURE = True
+
+ABSOLUTE_URL_OVERRIDES = {'auth.user': lambda o: "/users/%s/" % o.username}


### PR DESCRIPTION
Django 1.7 removed the get_absolute_url method from the user model