### PR TITLE
Remove secure cookie setting from base

### DIFF
--- a/wikipendium/settings/base.py
+++ b/wikipendium/settings/base.py
@@ -191,6 +191,4 @@ CACHES = {
     },
 }
 
-SESSION_COOKIE_SECURE = True
-
 ABSOLUTE_URL_OVERRIDES = {'auth.user': lambda o: "/users/%s/" % o.username}


### PR DESCRIPTION
The setting has been added to local settings on the server, so it
doesn't need to be in the base.py file.
This way, you don't have to override it back to False in development
setups not using HTTPS.