### PR TITLE
Improve article header on small screens

### DIFF
--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -2218,6 +2218,10 @@ body.fixed-header #content {
     padding-top: 50px;
 }
 
+.article-nav {
+    display: inline-block;
+}
+
 @media all and (max-width: 650px) {
     body.fixed-header #content {
         padding-top: 75px;

--- a/wikipendium/wiki/templates/article.html
+++ b/wikipendium/wiki/templates/article.html
@@ -6,11 +6,35 @@
 {% block body_class %}article fixed-header{% endblock %}
 
 {% block nav %}
-<a class=button href=/new/>Create article</a>
-{% language_chooser language_list articleContent %}
-<div class=button-group style=inline-block>
-    <a class="button edit-link" href={{ articleContent.get_edit_url }}>Edit</a>
-    <a class="button history-link" href={{ articleContent.get_history_url }}>History</a>
+<div class=article-nav>
+    <div class=hide-on-mobile>
+        <a class=button href=/new/>Create article</a>
+        {% language_chooser language_list articleContent %}
+        <div class=button-group style=inline-block>
+            <a class="button hidden-sm edit-link" href={{ articleContent.get_edit_url }}>Edit</a>
+            <a class="button history-link" href={{ articleContent.get_history_url }}>History</a>
+        </div>
+    </div>
+
+    <div class=show-on-mobile>
+        <div class="has-dropdown button-dropdown">
+            <a href=# class=button data-toggle=dropdown>
+                Tools
+                <span class=caret></span>
+            </a>
+            <ul class="dropdown right">
+                <li><a class=edit-link href={{ articleContent.get_edit_url }}>Edit</a></li>
+                <li><a class=history-link href={{ articleContent.get_history_url }}>History</a></li>
+                <hr>
+                {% for language, language_article_content_url in language_list %}
+                    <li><a href={{ language_article_content_url }}>Read in {{ language }}</a></li>
+                {% endfor %}
+                <li><a href={{ articleContent.get_add_language_url }}>Add language</a></li>
+                <hr>
+                <li><a href=/new/>Create new article</a></li>
+            </ul>
+        </div>
+    </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
This commit shoves some of the article header buttons into a dropdown
menu on small screens. This lets the header take up less space
on-screen, freeing up valuable screen real-estate.

![image](https://cloud.githubusercontent.com/assets/578029/7623356/15e351e2-f98e-11e4-9328-6da6bc987cf6.png)
