### PR TITLE
Reset styling for cm-keyword in codemirror

### DIFF
--- a/wikipendium/wiki/static/codemirror/wikipendium.css
+++ b/wikipendium/wiki/static/codemirror/wikipendium.css
@@ -1,4 +1,4 @@
-.cm-s-wikipendium span.cm-keyword {line-height: 1em; font-weight: bold; color: #5A5CAD; }
+.cm-s-wikipendium span.cm-keyword {color: black;}
 .cm-s-wikipendium span.cm-atom {color: #6C8CD5;}
 .cm-s-wikipendium span.cm-number {color: #164;}
 .cm-s-wikipendium span.cm-def {text-decoration:underline;}


### PR DESCRIPTION
It is only used for level 3 indented lists, which shouldn't have any
special styling.