### PR TITLE
Shrink text on printing

### DIFF
--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -2853,6 +2853,10 @@ input[readonly=True]{
  * PRINTING
 *******************/
 @media print {
+    body {
+      font-size: 10px;
+    }
+
     body.fixed-header .header-wrapper {
         position: relative;
         -webkit-box-shadow: none;


### PR DESCRIPTION
This fixes #339.

Before on the right, after on the left.
![image](https://cloud.githubusercontent.com/assets/1488921/7749908/24fc0d56-ffd1-11e4-95a9-6b157b60ecc8.png)
