### PR TITLE
Remove underlines from links in paragraphs

### DIFF
--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -820,10 +820,6 @@ a:hover {
   text-decoration: underline;
 }
 
-p a {
-  text-decoration: underline;
-}
-
 ul, ol {
   padding-left: 30px;
   margin: 0;


### PR DESCRIPTION
Until now, link styling in compendiums have been inconsistent.
Links in lists and tables have been displayed without underlines (only
on hover), while links in paragraphs have always had underlines.

Links are already separated enough from the text with their different
color, so for consistency and reduced noise, this removes the
underline styling from the links.

Before:
![screenshot 2015-05-21 16 48 10](https://cloud.githubusercontent.com/assets/1413267/7751278/63c34740-ffd9-11e4-8f25-74335b4e19b7.png)

After:
![screenshot 2015-05-21 16 48 24](https://cloud.githubusercontent.com/assets/1413267/7751279/63c42cd2-ffd9-11e4-9294-a33e2232d666.png)
