### PR TITLE
Move toc-toggle to the right

### DIFF
--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -2304,8 +2304,8 @@ body.toc-hidden .toc {
 
 #toggle-toc {
     position: fixed;
-    top: 65px;
-    left: 252px;
+    top: 70px;
+    left: 290px;
     width: 35px;
     height: 35px;
     border-radius: 50%;
@@ -2328,9 +2328,9 @@ body.toc-hidden .toc {
 }
 
 body.toc-hidden #toggle-toc {
-    -webkit-transform: translateX(-230px) rotate(-180deg);
-    -moz-transform: translateX(-230px) rotate(-180deg);
-    transform: translateX(-230px) rotate(-180deg);
+    -webkit-transform: translateX(-270px) rotate(-180deg);
+    -moz-transform: translateX(-270px) rotate(-180deg);
+    transform: translateX(-270px) rotate(-180deg);
 }
 
 .toctitle {


### PR DESCRIPTION
The offset between the toc and the toggle is now constant

This also fixes #331, since the button is no longer placed where the
scrollbar is on windows.

![screenshot 2015-05-23 13 12 55](https://cloud.githubusercontent.com/assets/1413267/7783753/7588d2f4-014d-11e5-8802-2e4b7b23b57d.png)
