### PR TITLE
Fix page-footer height

### DIFF
--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -577,11 +577,11 @@ img.native-width {
   min-height: 100%;
   height: auto !important;
   height: 100%;
-  margin: 0 auto -40px; /* the bottom margin is the negative value of the footer's height */
+  margin: 0 auto -200px; /* the bottom margin is the negative value of the footer's height */
 }
 #page-footer,
 #push {
-  height: 40px;
+  height: 200px;
 }
 
 @media screen and (max-width: 980px) {


### PR DESCRIPTION
The sticky footer implementation we currently use depends on a
fixed-height footer. Ever since we added the paypal donation to the
footer, this fixed height has been too small, resulting in scrollbars on
even very short articles.

This restores the footer back to being perfectly on the bottom of the
screen on pages with little content.


No more looking like this:
![screenshot 2015-05-24 22 57 04](https://cloud.githubusercontent.com/assets/1413267/7789622/4127cfe4-0268-11e5-9caf-fe4fa8d407d6.png)
