### PR TITLE
Fix layout on article error pages

### DIFF
--- a/wikipendium/wiki/templates/missing_language.html
+++ b/wikipendium/wiki/templates/missing_language.html
@@ -3,7 +3,7 @@
 
 {% block title %}This article is not available in this language -{% endblock %}
 
-{% block body_class %}article fixed-header{% endblock %}
+{% block body_class %}toc-hidden article fixed-header{% endblock %}
 
 {% block content %}
 <div id=article class=serif>

--- a/wikipendium/wiki/templates/no_article.html
+++ b/wikipendium/wiki/templates/no_article.html
@@ -3,7 +3,7 @@
 
 {% block title %}This article does not exist -{% endblock %}
 
-{% block body_class %}article fixed-header{% endblock %}
+{% block body_class %}toc-hidden article fixed-header{% endblock %}
 
 {% block content %}
 <div id=article class=serif>


### PR DESCRIPTION
Removes offset accounting for presence of not-present toc

Restores this funky-looking thing back to normal:
![screenshot 2015-05-25 00 47 52](https://cloud.githubusercontent.com/assets/1413267/7790047/c1e6935e-0277-11e5-805a-036888e7a927.png)
