### PR TITLE
Remove scroll-unbreak hack for safari

### DIFF
--- a/wikipendium/wiki/static/js/script.js
+++ b/wikipendium/wiki/static/js/script.js
@@ -179,11 +179,6 @@ $(function(){
         $('#overlay').show();
     });
 
-    $(window).on('hashchange', function(e) {
-        // Impressively, this ensures scrolling doesn't break (as much) in Safari
-        $('.toc').toggleClass('safari-reload-scroll-hack');
-    });
-
     $('.section1 h1').click(function(e) {
         $(this).parent('.section1').toggleClass('open');
     });


### PR DESCRIPTION
It's not needed anymore after the highlights have been introduced.
Constantly updating the DOM of the toc seems to make sure (even better
than before) that the scrolling never stops working.