### PR TITLE
Align toc header with text in toc

### DIFF
--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -2320,7 +2320,7 @@ body.toc-hidden #toggle-toc {
 .toctitle {
     font-weight: bold;
     font-variant: small-caps;
-    padding: 30px;
+    padding: 34px;
 }
 
 


### PR DESCRIPTION
With the highlights, an extra 4px padding was added to the list
elements.
This realigns the toc header with the list elements.

Ugly un-alignedness:
![screenshot 2015-05-25 11 06 23](https://cloud.githubusercontent.com/assets/1413267/7794799/a4464310-02ce-11e5-9de5-1d6b3dc4ce6b.png)

Much nicer aligned-sexyness:
![screenshot 2015-05-25 11 08 55](https://cloud.githubusercontent.com/assets/1413267/7794800/a4467452-02ce-11e5-96af-599b48aca0c6.png)
