### PR TITLE
Replace innerText with textContent

### DIFF
--- a/wikipendium/wiki/static/js/script.js
+++ b/wikipendium/wiki/static/js/script.js
@@ -107,7 +107,7 @@ $(function(){
                 var li = document.createElement('li');
                 var a = document.createElement('a');
                 a.setAttribute('href', '#' + node.lineNumber);
-                a.innerText = node.text;
+                a.textContent = node.text;
                 li.appendChild(a);
 
                 if (node.children.length > 0) {


### PR DESCRIPTION
innerText is a non-standard property, while textContent is the
spec-compliant way of setting text on DOM elements.
https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent

No more:
![screenshot 2015-05-25 15 42 43](https://cloud.githubusercontent.com/assets/1413267/7798035/b79f20d2-02f4-11e5-9a18-06c218d57eaa.png)
