### PR TITLE
Fix toc highlighting not always selecting the correct section

### DIFF
--- a/wikipendium/wiki/static/js/script.js
+++ b/wikipendium/wiki/static/js/script.js
@@ -227,7 +227,9 @@ $(function(){
       var currentSection = sections.eq(0);
       for(var i = 0; i < sections.length; i++) {
         var section = sections.eq(i);
-        var offset = $(section).offset().top - scrollTop;
+        // Using floor to avoid half pixel problems
+        // scrollTop() returns an integer while offset().top can return a decimal
+        var offset = Math.floor($(section).offset().top - scrollTop);
         if(offset <= 0 && offset > bestOffset) {
           bestOffset = offset;
           currentSection = section;


### PR DESCRIPTION
If the offset is a decimal instead of an integer the calculation could return 1 > x > 0 when 0 is correct.
This is caused by scrollTop() only returning integers.

Example:

https://www.wikipendium.no/TDT4180_Menneske-maskin-interaksjon_MMI/nb/#personas

Clicking "Personas" in the table of contents will select the preview section instead.
This is because the cartoon (img) has a calculated height of 787.906px. 
This value gets rounded by scrollTop(), but not offset().top. 