### PR TITLE
Fix responsive issues with contributors list

### DIFF
--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -2329,15 +2329,13 @@ body.toc-hidden #toggle-toc {
         padding-left: 50px;
     }
 
-    body.article:not(.toc-hidden) #content,
-    body.article:not(.toc-hidden) #page-footer {
+    body.article:not(.toc-hidden) {
         padding-left: 315px;
     }
 }
 
 @media screen and (min-width: 1330px) {
-    body.article:not(.toc-hidden) #content,
-    body.article:not(.toc-hidden) #page-footer {
+    body.article:not(.toc-hidden) {
         padding-left: 0;
     }
 }

--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -2224,13 +2224,11 @@ body.fixed-header #content {
     margin-top: -50px;
 }
 
-body.article .contributors {
-    margin-top: 20px;
-}
-
 body.article .contributors,
 body.article .last-updated {
-    margin-bottom: 10px;
+    position: relative;
+    max-width: 640px;
+    margin: 20px auto 10px;
 }
 
 h1,h2,h3,h4,h5,h6{


### PR DESCRIPTION
When the toc is visible, instead of adding padding within the content
container, it is now added to the body. This lets the content retain its
640px width, since the padding doesn't eat from the constrained
max-width of the container.

Previously – content is shrinked:
![screenshot 2015-05-27 11 53 45](https://cloud.githubusercontent.com/assets/1413267/7833605/53798e06-0468-11e5-9b23-c318575e1314.png)

Now – full 640px width with proper centering:
![screenshot 2015-05-27 11 53 21](https://cloud.githubusercontent.com/assets/1413267/7833619/6778fd24-0468-11e5-8bb6-d59d93023b68.png)

The 640px max width of contributors list:
![screenshot 2015-05-27 12 01 47](https://cloud.githubusercontent.com/assets/1413267/7833628/730a3e78-0468-11e5-96f0-540900e64229.png)

