### PR TITLE
Improve typography in editor

### DIFF
--- a/wikipendium/wiki/static/codemirror/codemirror.css
+++ b/wikipendium/wiki/static/codemirror/codemirror.css
@@ -2,7 +2,7 @@
 
 .CodeMirror {
   /* Set height, width, borders, and global font properties here */
-  font-family: monospace;
+  font-family: menlo, consolas, monospace;
   height: 300px;
 }
 .CodeMirror-scroll {
@@ -109,11 +109,12 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
    the editor. You probably shouldn't touch them. */
 
 .CodeMirror {
-  line-height: 1;
+  font-size: 15px;
+  line-height: 1.3;
   position: relative;
   overflow: hidden;
   background: white;
-  color: black;
+  color: #424242;
 }
 
 .CodeMirror-scroll {

--- a/wikipendium/wiki/static/codemirror/wikipendium.css
+++ b/wikipendium/wiki/static/codemirror/wikipendium.css
@@ -1,10 +1,10 @@
-.cm-s-wikipendium span.cm-keyword {color: black;}
+.cm-s-wikipendium span.cm-keyword {}
 .cm-s-wikipendium span.cm-atom {color: #6C8CD5;}
 .cm-s-wikipendium span.cm-number {color: #164;}
 .cm-s-wikipendium span.cm-def {text-decoration:underline;}
-.cm-s-wikipendium span.cm-variable {color: black; }
-.cm-s-wikipendium span.cm-variable-2 {color:black;}
-.cm-s-wikipendium span.cm-variable-3 {color: black; }
+.cm-s-wikipendium span.cm-variable {}
+.cm-s-wikipendium span.cm-variable-2 {}
+.cm-s-wikipendium span.cm-variable-3 {}
 .cm-s-wikipendium span.cm-property {}
 .cm-s-wikipendium span.cm-operator {}
 .cm-s-wikipendium span.cm-comment {color: #0080FF; font-style: italic;}


### PR DESCRIPTION
Larger size with more relaxed line-height, better font-family, and
slightly reduced contrast.

I haven't tested this on Windows, but I would assume Consolas to be the best widely-available fixed-width alternative.

From:
![screenshot 2015-05-27 12 33 10](https://cloud.githubusercontent.com/assets/1413267/7834125/9ed4b886-046c-11e5-908d-973ad6538b36.png)

To:
![screenshot 2015-05-27 12 33 18](https://cloud.githubusercontent.com/assets/1413267/7834124/9ed4658e-046c-11e5-92bb-d44c741d59c1.png)
