### PR TITLE
Update django-registration to v1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django==1.8.2
-django-registration-redux==1.1
+django-registration-redux==1.2
 git+git://github.com/wikipendium/Python-Markdown.git@5e9e809#egg=markdown
 git+git://github.com/wikipendium/python-markdown-mathjax.git#egg=markdown_mathjax
 git+git://github.com/stianjensen/mdx_outline.git


### PR DESCRIPTION
This will silence the warning we currently get while deploying, about
'ForeignKey(unique=True) is usually better served by a OneToOneField'.

I have a small issue, because this new version includes migrations for django 1.7 which need to be fake applied. How to deal with that when deploying?

@cristeahub edit: This fixes #377 .