### PR TITLE
Use EmailField for email validation

### DIFF
--- a/wikipendium/user/forms.py
+++ b/wikipendium/user/forms.py
@@ -1,4 +1,4 @@
-from django.forms import Form, CharField, ValidationError
+from django.forms import Form, CharField, EmailField, ValidationError
 from django.contrib.auth.models import User
 
 
@@ -15,4 +15,4 @@ class UserChangeForm(Form):
 
 
 class EmailChangeForm(Form):
-    email = CharField(max_length=75, label='New email')
+    email = EmailField(max_length=75, label='New email')

--- a/wikipendium/user/forms.py
+++ b/wikipendium/user/forms.py
@@ -15,4 +15,4 @@ class UserChangeForm(Form):
 
 
 class EmailChangeForm(Form):
-    email = EmailField(max_length=75, label='New email')
+    email = EmailField(max_length=254, label='New email')


### PR DESCRIPTION
Because let's utilize HTML5's type=email instead of type=text