### PR TITLE
Add margin notes to articles

### DIFF
--- a/wikipendium/wiki/markdown_extra/marginnotes.py
+++ b/wikipendium/wiki/markdown_extra/marginnotes.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+"""
+Renders margin notes.
+
+Markdown syntax:
+
+[#] This is a margin note.
+
+"""
+
+
+from markdown import Extension
+from markdown.blockprocessors import BlockProcessor
+from markdown.util import etree
+
+
+class MarginNotesProcessor(BlockProcessor):
+
+    MARGIN_NOTES_MARKER = '[#]'
+
+    def test(self, parent, block):
+        """ Test if block is a margin note """
+        return block.startswith(self.MARGIN_NOTES_MARKER)
+
+    def run(self, parent, blocks):
+        """ Convert markdown to margin notes """
+        block = blocks.pop(0)
+        if self.test(parent, block):
+            note = etree.SubElement(parent, 'div')
+            note.attrib['class'] = 'margin-note'
+            note.text = block[len(self.MARGIN_NOTES_MARKER):]
+
+
+class MarginNotesExtension(Extension):
+    """ Add marginnotes to Markdown. """
+
+    def extendMarkdown(self, md, md_globals):
+        md.registerExtension(self)
+
+        md.parser.blockprocessors.add('marginnotes',
+                                      MarginNotesProcessor(md.parser),
+                                      '<hashheader')

--- a/wikipendium/wiki/models.py
+++ b/wikipendium/wiki/models.py
@@ -9,6 +9,7 @@ from markdown import Markdown
 from markdown.extensions.toc import TocExtension
 from .markdown_extra.markdown_wikitables import WikiTableExtension
 from .markdown_extra.nofollow import NofollowExtension
+from .markdown_extra.marginnotes import MarginNotesExtension
 from wikipendium.cache.decorators import cache_model_method
 from re import sub
 from taggit.managers import TaggableManager
@@ -164,6 +165,7 @@ class ArticleContent(models.Model):
     def get_html_content(self):
         wikitables = WikiTableExtension()
         nofollow = NofollowExtension()
+        margin_notes = MarginNotesExtension()
         toc = TocExtension([('title', 'Table of Contents')])
 
         md = Markdown(
@@ -174,6 +176,7 @@ class ArticleContent(models.Model):
                 wikitables,
                 nofollow,
                 'def_list',
+                margin_notes,
             ],
             output_format='html5',
             safe_mode='escape'

--- a/wikipendium/wiki/static/css/master.css
+++ b/wikipendium/wiki/static/css/master.css
@@ -2472,6 +2472,35 @@ pre code {
     padding: 0 10px 0 0;
 }
 
+#article .margin-note {
+  position: relative;
+  float: right;
+  border-left: 3px solid #089;
+  background: #fafafa;
+  width: 350px;
+  margin-right: -365px;
+  font-size: 12px;
+  line-height: 16px;
+  padding: 10px;
+}
+
+@media all and (max-width: 1399px) {
+  #article .margin-note {
+    width: 250px;
+    margin-right: -265px;
+  }
+}
+
+@media all and (max-width: 1329px) {
+  #article .margin-note {
+    width: 100%;
+    margin-right: 0;
+    margin-bottom: 15px;
+  }
+}
+
+
+
 /******************
  * NO ARTICLE
 ******************/

--- a/wikipendium/wiki/templates/writing_guide.html
+++ b/wikipendium/wiki/templates/writing_guide.html
@@ -8,6 +8,9 @@
         <a href=#links-and-images-tab>Links & Images</a>
     </li>
     <li>
+        <a href=#margin-notes-tab>Margin Notes</a>
+    </li>
+    <li>
         <a href=#code-tab>Code</a>
     </li>
     <li>
@@ -115,6 +118,12 @@ Car
             <a href="http://en.wikibooks.org/wiki/LaTeX/Mathematics" target=_blank>
                 See a full LaTeX/Math documentation here</a>.
         </p>
+    </div>
+
+    <div class=tab id="margin-notes-tab">
+        <h4>Margin Notes</h4>
+        <pre>[#] This is a margin note that can provide additional
+information or commentary to the main text of a compendium.</pre>
     </div>
 
     <div class=tab id="code-tab">


### PR DESCRIPTION
Margin notes are a type of footnote or commentary that appear inline or
in the margins of the text close to where they are defined, rather than
at the bottom as regular footnotes do. Margin notes are declared in
Markdown using the just-invented syntax:

[#] This is a margin note.

Two possible use cases:

![image](https://cloud.githubusercontent.com/assets/578029/9562641/c773de3a-4e71-11e5-99ab-df01b4d8b2e4.png)
