### PR TITLE
Remove empty tmp file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ wikipendium/settings/local.py
 venv/*
 static/*
 *.iml
+
+tmp/


### PR DESCRIPTION
fdcda6e8b735b51eb535cb0862a621725243cd42 introduced a new way to merge
compendiums. With this came a temp file. This prq removes that temp
file, and puts the tmp folder in gitignore.