### PR TITLE
Revert "Remove empty tmp file"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ wikipendium/settings/local.py
 venv/*
 static/*
 *.iml
-
-tmp/


### PR DESCRIPTION
Reverts stianjensen/wikipendium.no#384

That temp file was a placeholder to make sure that the tmp/diff folder was present. Merging does not work without that folder!