### PR TITLE
Add clean command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,9 @@ setup:
 .PHONY: shell
 shell:
 	python manage.py shell
+
+.PHONY: clean
+clean:
+	find . -name '*.pyc' -delete
+	find . -name '__pycache__' -delete
+	find . -type d -empty -delete


### PR DESCRIPTION
Old .pyc files can create unwanted ghosting behavior, so having a clean
command that deletes them is useful.