### PR TITLE
Increase article/compendium naming consistency

### DIFF
--- a/wikipendium/wiki/templates/article.html
+++ b/wikipendium/wiki/templates/article.html
@@ -23,7 +23,7 @@
 {% block nav %}
 <div class=article-nav>
     <div class=hide-on-mobile>
-        <a class=button href=/new/>Create article</a>
+        <a class=button href=/new/>Create compendium</a>
         {% language_chooser language_list articleContent %}
         <div class=button-group style=inline-block>
             <a class="button hidden-sm edit-link" href={{ articleContent.get_edit_url }}>Edit</a>
@@ -46,7 +46,7 @@
                 {% endfor %}
                 <li><a href={{ articleContent.get_add_language_url }}>Add language</a></li>
                 <hr>
-                <li><a href=/new/>Create new article</a></li>
+                <li><a href=/new/>Create new compendium</a></li>
             </ul>
         </div>
     </div>

--- a/wikipendium/wiki/templates/edit.html
+++ b/wikipendium/wiki/templates/edit.html
@@ -10,13 +10,13 @@
 {% block nav %}
 <div class=article-nav>
     <div class=hide-on-mobile>
-        <a class=button href=/new/>Create article</a>
+        <a class=button href=/new/>Create compendium</a>
 
         {% if articleContent %}
             {% language_chooser language_list articleContent %}
 
             <div class=button-group style=inline-block>
-                <a class=button href={{ articleContent.get_absolute_url }}>Article</a>
+                <a class=button href={{ articleContent.get_absolute_url }}>Compendium</a>
                 <a class="button history-link" href={{ articleContent.get_history_url }}>History</a>
             </div>
         {% endif %}
@@ -30,7 +30,7 @@
                     <span class=caret></span>
                 </a>
                 <ul class="dropdown right">
-                    <li><a class=edit-link href={{ articleContent.get_absolute_url }}>Article</a></li>
+                    <li><a class=edit-link href={{ articleContent.get_absolute_url }}>Compendium</a></li>
                     <li><a class=history-link href={{ articleContent.get_history_url }}>History</a></li>
                     <hr>
                     {% for language, language_article_content_url in language_list %}
@@ -38,11 +38,11 @@
                     {% endfor %}
                     <li><a href={{ articleContent.get_add_language_url }}>Add language</a></li>
                     <hr>
-                    <li><a href=/new/>Create new article</a></li>
+                    <li><a href=/new/>Create new compendium</a></li>
                 </ul>
             </div>
         {% else %}
-            <a class=button href=/new/>Create article</a>
+            <a class=button href=/new/>Create compendium</a>
         {% endif %}
     </div>
 </div>

--- a/wikipendium/wiki/templates/history.html
+++ b/wikipendium/wiki/templates/history.html
@@ -7,7 +7,7 @@ History: {{ article.slug }} –
 {% block body_class %}fixed-header{% endblock %}
 
 {% block nav %}
-<a class=button href="{{ back_url }}">Article</a>
+<a class=button href="{{ back_url }}">Compendium</a>
 {% endblock %}
 
 {% block content %}

--- a/wikipendium/wiki/templates/history_single.html
+++ b/wikipendium/wiki/templates/history_single.html
@@ -9,14 +9,14 @@ Diff: {{ ac.article.slug }} –
 {% block nav %}
 <div class=button-group style=inline-block>
     <a class=button href="{{ ac.get_history_url }}">History</a>
-    <a class=button href="{{ back_url }}">Article</a>
+    <a class=button href="{{ back_url }}">Compendium</a>
 </div>
 {% endblock %}
 
 {% block content %}
 
 <div class=info>
-    This is an old version of the article, written {{ac.updated}} Changes made in this revision were made by <a href="{{ ac.edited_by.get_absolute_url }}">{{ ac.edited_by }}</a>.
+    This is an old version of the compendium, written {{ac.updated}} Changes made in this revision were made by <a href="{{ ac.edited_by.get_absolute_url }}">{{ ac.edited_by }}</a>.
 </div>
 
 <div style=overflow:hidden>

--- a/wikipendium/wiki/templates/index.html
+++ b/wikipendium/wiki/templates/index.html
@@ -7,7 +7,7 @@
 {% block body_class %}frontpage{% endblock %}
 
 {% block nav %}
-<a class=button href=/new/>Create article</a>
+<a class=button href=/new/>Create compendium</a>
 {% endblock %}
 
 {% block content %}

--- a/wikipendium/wiki/templates/missing_language.html
+++ b/wikipendium/wiki/templates/missing_language.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load extras %}
 
-{% block title %}This article is not available in this language -{% endblock %}
+{% block title %}This compendium is not available in this language -{% endblock %}
 
 {% block body_class %}toc-hidden article fixed-header{% endblock %}
 
@@ -11,7 +11,7 @@
         {% if language_does_not_exist %}
             <h1 class=title>This language does not exist.</h1>
         {% else %}
-            <h1 class=title>This article is not available in {{ language_name }}.</h1>
+            <h1 class=title>This compendium is not available in {{ language_name }}.</h1>
             <h2><a href="{{ create_url }}">Create it?</a></h2>
         {% endif %}
     </div>

--- a/wikipendium/wiki/templates/no_article.html
+++ b/wikipendium/wiki/templates/no_article.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 {% load extras %}
 
-{% block title %}This article does not exist -{% endblock %}
+{% block title %}This compendium does not exist -{% endblock %}
 
 {% block body_class %}toc-hidden article fixed-header{% endblock %}
 
 {% block content %}
 <div id=article class=serif>
     <div class=no-article>
-        <h1 class=title>An article with the course code {{ slug }} does not exist.</h1>
+        <h1 class=title>A compendium with the course code {{ slug }} does not exist.</h1>
         <h2><a href="{{ create_url }}">Create it?</a></h2>
     </div>
 </div>

--- a/wikipendium/wiki/templates/writing_guide.html
+++ b/wikipendium/wiki/templates/writing_guide.html
@@ -91,7 +91,7 @@ Car
         <pre><code>[This is a link](http://tothispage.com/)</code></pre>
         <p>If you want to show the link URL, you can simply type:</p>
         <pre><code>&lt;http://theurl.com/&gt;</code></pre>
-        <p>To link to other sections in the article, use this format:</p>
+        <p>To link to other sections in the compendium, use this format:</p>
         <pre><code>[Section Name](#section-name)</code></pre>
         <h4>Images</h4>
         <pre><code>![Alt text](http://url.to/image.png)</code></pre>

--- a/wikipendium/wiki/views.py
+++ b/wikipendium/wiki/views.py
@@ -166,7 +166,7 @@ def new(request, slug=None):
     return render(request, 'edit.html', {
         "mathjax": True,
         "form": form,
-        "title": "Create article",
+        "title": "Create compendium",
     })
 
 


### PR DESCRIPTION
We used to refer to compendiums interchangably as articles in the UI.
This commit makes sure that the compendiums are always referred to as
compendiums for consistency's sake.