### PR TITLE
Specify python venv for django-compressor

### DIFF
--- a/wikipendium/settings/base.py
+++ b/wikipendium/settings/base.py
@@ -202,5 +202,5 @@ SESSION_COOKIE_SECURE = True
 ABSOLUTE_URL_OVERRIDES = {'auth.user': lambda o: "/users/%s/" % o.username}
 
 COMPRESS_PRECOMPILERS = (
-    ('text/x-scss', 'python wikipendium/utils/scss-cli.py {infile}'),
+    ('text/x-scss', 'venv/bin/python wikipendium/utils/scss-cli.py {infile}'),
 )


### PR DESCRIPTION
This is needed for django-compressor to work when run from uwsgi.