### PR TITLE
Remove space in cache_page_per_user key

### DIFF
--- a/wikipendium/cache/decorators.py
+++ b/wikipendium/cache/decorators.py
@@ -13,7 +13,7 @@ def _make_cache_key_from_function(fn, *args, **kwargs):
 def cache_page_per_user(fn, *args, **kwargs):
     def key(request, *args, **kwargs):
         return (_make_cache_key_from_function(fn, *args, **kwargs) +
-                'user(pk=%s, username=%s)' % (
+                'user(pk=%s,username=%s)' % (
                     request.user.pk
                     if request.user.is_authenticated()
                     else 'None', request.user.username))


### PR DESCRIPTION
Some cache backends (e.g. Memcached) do not work properly with cache
keys that contain spaces. This removes the annoying CacheKeyWarning that
currently littering logs.


Example warning:
> django/core/cache/backends/base.py:224: CacheKeyWarning: Cache key contains characters that will cause errors if used with memcached: u':1:wikipendium.wiki.views.cachable_article((args:4381),(kwargs:6916483424922339066))user(pk=None, username=)'
  CacheKeyWarning)
