### PR TITLE
Explicitly specify slug redirect as permanent

### DIFF
--- a/wikipendium/urls.py
+++ b/wikipendium/urls.py
@@ -40,7 +40,7 @@ urlpatterns = patterns(
     url(r'^tag/(?P<tag>[a-zA-Z0-9_-]+)/$', 'tag'),
 
     url(r'^' + article_regex + '/$',
-        RedirectView.as_view(url='/%(slug)s')),
+        RedirectView.as_view(url='/%(slug)s', permanent=True)),
 
     url(r'^' + article_regex + '$', 'article'),
     url(r'^' + article_regex + '/',


### PR DESCRIPTION
The default value will change from True to False in Django 1.9, and we
want permanent redirects.

This quells some warnings that typically look like this:

> wikipendium/urls.py:50: RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.
