### PR TITLE
Add app_label to jitishcron TaskExecution model

### DIFF
--- a/wikipendium/jitishcron/models.py
+++ b/wikipendium/jitishcron/models.py
@@ -9,6 +9,7 @@ class TaskExecution(models.Model):
 
     class Meta:
         unique_together = ('key', 'execution_number')
+        app_label = 'jitishcron'
 
     def __unicode__(self):
         return '%s:%s' % (self.key, self.time)


### PR DESCRIPTION
The TaskExecution model is loaded before apps are done loading, which in
Django 1.9 will no longer be permitted unless the model explicitly
specifies an app_label.

This silences some runserver warnings that look like this:
> wikipendium/jitishcron/models.py:5: RemovedInDjango19Warning: Model class wikipendium.jitishcron.models.TaskExecution doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
