### PR TITLE
Normalize line endings on save

### DIFF
--- a/wikipendium/wiki/models.py
+++ b/wikipendium/wiki/models.py
@@ -135,6 +135,8 @@ class ArticleContent(models.Model):
         if '/' in self.title:
             raise ValidationError('Title cannot contain slashes')
 
+        self.content.replace('\r\n', '\n').replace('\r', '\n')
+
     def get_contributors(self):
         filtered = ArticleContent.objects.filter(article=self.article,
                                                  lang=self.lang,


### PR DESCRIPTION
This fixes #323.

We may also go over all existing article contents afterwards and normalize their line endings to fix any existing issues with new line conversion.