### PR TITLE
Cleanup breakpoints for better mobile and small-window browsing

### DIFF
--- a/wikipendium/static/scss/master.scss
+++ b/wikipendium/static/scss/master.scss
@@ -18,7 +18,7 @@ body.fixed-header .header-wrapper {
   }
 }
 
-@media all and (max-width: 650px) {
+@media all and (max-width: 600px) {
   .header-logo-link .ikipendium {
     display: none;
   }

--- a/wikipendium/wiki/static/scss/article.scss
+++ b/wikipendium/wiki/static/scss/article.scss
@@ -2,12 +2,6 @@
   display: inline-block;
 }
 
-@media all and (max-width: 650px) {
-  body.fixed-header #content {
-    padding-top: 75px;
-  }
-}
-
 #article {
   width: auto;
   max-width: 640px;

--- a/wikipendium/wiki/static/scss/article.scss
+++ b/wikipendium/wiki/static/scss/article.scss
@@ -117,7 +117,7 @@ body.toc-hidden #toggle-toc {
   padding: 34px;
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 601px) {
   body {
     &.fixed-header .header-wrapper .container {
       padding-left: 50px;
@@ -128,13 +128,27 @@ body.toc-hidden #toggle-toc {
   }
 }
 
+@media screen and (min-width: 601px) and (max-width: 768px) {
+  body.toc-hidden {
+    #article {
+      padding-top: 60px;
+
+      .title {
+        position: absolute;
+        left: 57px;
+        margin-top: -60px;
+      }
+    }
+  }
+}
+
 @media screen and (min-width: 1330px) {
   body.article:not(.toc-hidden) {
     padding-left: 0;
   }
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 600px) {
   .toc, #toggle-toc {
     display: none;
   }


### PR DESCRIPTION
Before:
<img width="859" alt="screenshot 2015-09-06 20 00 37" src="https://cloud.githubusercontent.com/assets/1413267/9705815/f73e41ee-54d1-11e5-8552-9bc5ea8662c4.png">

After:
<img width="810" alt="screenshot 2015-09-06 20 00 19" src="https://cloud.githubusercontent.com/assets/1413267/9705814/f71adf92-54d1-11e5-8d2e-ce4135c487c2.png">
