### PR TITLE
Fix preview, so it works for new articles

### DIFF
--- a/wikipendium/static/js/script.js
+++ b/wikipendium/static/js/script.js
@@ -63,8 +63,7 @@ $(function(){
         });
 
         $('#content').on('click', '.open-preview-button', function() {
-            var path = window.location.pathname.replace('edit', 'preview');
-            $.post(path, {content: codeMirror.getValue()}, function(data) {
+            $.post('/preview/', {content: codeMirror.getValue()}, function(data) {
                 $('#preview-button')
                     .removeClass('open-preview-button')
                     .addClass('cancel-preview-button')

--- a/wikipendium/urls.py
+++ b/wikipendium/urls.py
@@ -22,7 +22,6 @@ article_patterns = patterns(
     'wikipendium.wiki.views',
     url(r'^add_tag/$', 'add_tag_to_article'),
     url(r'^edit/$', 'edit'),
-    url(r'^preview/$', 'preview'),
     url(r'^history/$', 'history'),
     url(r'^history/(?P<id>\d+)/$', 'history_single'),
     url(r'^rss/$', ArticleLatestChangesRSSFeed()),
@@ -44,6 +43,7 @@ urlpatterns = patterns(
     url(r'^$', 'home', name='home'),
     url(r'^new/(?P<slug>[' + Article.slug_regex + ']+)?$',
         'new', name='newarticle'),
+    url(r'^preview/$', 'preview'),
 
     url(r'^', include('wikipendium.user.urls')),
 

--- a/wikipendium/wiki/views.py
+++ b/wikipendium/wiki/views.py
@@ -233,14 +233,10 @@ def edit(request, slug, lang='en'):
 
 
 @csrf_exempt
-def preview(request, slug, lang='en'):
-    article = get_object_or_404(Article, slug=slug)
-
+def preview(request):
     if request.method == 'POST':
         content = request.POST.get('content', '')
-        articleContent = ArticleContent(
-            article=article, lang=lang, content=content
-        )
+        articleContent = ArticleContent(content=content)
         html = articleContent.get_html_content()
         return JsonResponse(html)
     return JsonResponse({'error': 'Method not allowed'})


### PR DESCRIPTION
Removes dependency on having a related article object, as it is not
really necessary, and enables preview to work for all edit modes.