### PR TITLE
Move remaining GitHub dependencies to wikipendium

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ django==1.8.4
 django-registration-redux==1.2
 git+git://github.com/wikipendium/Python-Markdown.git@5e9e809#egg=markdown
 git+git://github.com/wikipendium/python-markdown-mathjax.git#egg=markdown_mathjax
-git+git://github.com/stianjensen/mdx_outline.git
+git+git://github.com/wikipendium/mdx_outline.git
 fabric==1.10.2
 pytz==2015.4
 boto==2.38.0
@@ -10,7 +10,7 @@ newrelic==2.54.0.41
 django-mailgun==0.2.2
 django-compressor==1.5
 django-taggit==0.17.0
-git+git://github.com/stianjensen/django-dumpdb.git
+git+git://github.com/wikipendium/django-dumpdb.git
 flake8==2.4.1
 flake8-quotes==0.0.1
 libsass==0.8.3


### PR DESCRIPTION
This updates requirements.txt to use GitHub dependencies owned by the
Wikipendium GitHub organization.