### PR TITLE
Improve performance by prefetching foreign keys

### DIFF
--- a/wikipendium/user/views.py
+++ b/wikipendium/user/views.py
@@ -12,8 +12,11 @@ from registration.backends.simple.views import RegistrationView
 def profile(request, username):
     user = get_object_or_404(User, username=username)
 
-    contribution_article_contents = ArticleContent.objects.filter(
-        edited_by=user).order_by('-updated')
+    contribution_article_contents = (
+        ArticleContent.objects.filter(edited_by=user)
+                              .order_by('-updated')
+                              .select_related('article', 'edited_by')
+    )
 
     contributions = defaultdict(list)
     for article_content in contribution_article_contents:


### PR DESCRIPTION
Prefetch relevant foreign keys on the frontpage, compendium view,
history list and user page.

This reduces sql query complexity from one or more queries per
article/edit to only a handful of queries on some views, while some of
the more complex views still has some more complex queries that are
harder to quickly optimize.
Still, even for the most complex pages, these little tweaks reduce the
number of queries from what looks like 4*n to n queries, which is
noticable when loading pages in the browser.