### PR TITLE
Allow special characters in tag names

### DIFF
--- a/wikipendium/static/js/script.js
+++ b/wikipendium/static/js/script.js
@@ -310,8 +310,8 @@ $(function(){
             tagAdder.show();
             tagForm.hide();
             tagInput.val('');
-            tagUl.append($('<li><a href="/tag/' + tag + '">' + tag + '</a></li>'));
-          });
+            tagUl.append($('<li><a href="/tag/' + tag.slug + '">' + tag.name + '</a></li>'));
+          }, 'json');
         });
     }).apply($('.tags'));
 

--- a/wikipendium/urls.py
+++ b/wikipendium/urls.py
@@ -47,7 +47,7 @@ urlpatterns = patterns(
 
     url(r'^', include('wikipendium.user.urls')),
 
-    url(r'^tag/(?P<tag>[a-zA-Z0-9_-]+)/$', 'tag'),
+    url(r'^tag/(?P<tag_slug>[a-zA-Z0-9_-]+)/$', 'tag'),
 
     url(r'^' + article_regex + '/$',
         RedirectView.as_view(url='/%(slug)s', permanent=True)),

--- a/wikipendium/wiki/templates/article.html
+++ b/wikipendium/wiki/templates/article.html
@@ -73,7 +73,7 @@
         </div>
         <ul>
             {% for tag in articleContent.article.tags.all %}
-                <li><a href="/tag/{{ tag }}">{{ tag }}</a></li>
+                <li><a href="/tag/{{ tag.slug }}">{{ tag }}</a></li>
             {% endfor %}
         </ul>
         <form><input /></form>


### PR DESCRIPTION
Instead of requiring the name and slug to be identical, we always keep
the inputted name of the tag, and use the slug only for urls and lookup.

Tried creating a tag called 'Økonomi' the other day, and it was saved as 'konomi' :disappointed: 