### PR TITLE
Remove italic from editor code blocks

### DIFF
--- a/wikipendium/static/codemirror/wikipendium.css
+++ b/wikipendium/static/codemirror/wikipendium.css
@@ -7,7 +7,7 @@
 .cm-s-wikipendium span.cm-variable-3 {}
 .cm-s-wikipendium span.cm-property {}
 .cm-s-wikipendium span.cm-operator {}
-.cm-s-wikipendium span.cm-comment {color: #0080FF; font-style: italic;}
+.cm-s-wikipendium span.cm-comment {color: #0080FF;}
 .cm-s-wikipendium span.cm-string {color: red;}
 .cm-s-wikipendium span.cm-meta {color: yellow;}
 .cm-s-wikipendium span.cm-error {color: #f00;}


### PR DESCRIPTION
This fixes #425.

**bad**
<img width="508" alt="screenshot 2015-12-04 15 38 21" src="https://cloud.githubusercontent.com/assets/1413267/11592175/2cc31450-9a9d-11e5-9147-224f25b62ccc.png">
**good**
<img width="476" alt="screenshot 2015-12-04 15 38 26" src="https://cloud.githubusercontent.com/assets/1413267/11592174/2c9c49e2-9a9d-11e5-9f11-92dcb08b6a9a.png">