### PR TITLE
Add safeguard for when toc is not present

### DIFF
--- a/wikipendium/wiki/models.py
+++ b/wikipendium/wiki/models.py
@@ -191,7 +191,7 @@ class ArticleContent(models.Model):
         markdowned_text = md.convert(self.content)
         article = {
             'html': markdowned_text,
-            'toc': md.toc,
+            'toc': getattr(md, 'toc', None),
         }
         return article
 


### PR DESCRIPTION
For empty documents, the toc property is never added to the markdown
object.

This fixes #435.