### PR TITLE
Switch cdn url for mathjax

### DIFF
--- a/wikipendium/wiki/templates/base.html
+++ b/wikipendium/wiki/templates/base.html
@@ -72,7 +72,7 @@
       }
     });
     </script>
-    <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     {% endif %}
 </head>
 


### PR DESCRIPTION
The Mathjax CDN is shutting down on April 30th.
https://www.mathjax.org/cdn-shutting-down/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stianjensen/wikipendium.no/450)
<!-- Reviewable:end -->
