### PR TITLE
Update MathJax to 2.7.1

### DIFF
--- a/wikipendium/wiki/templates/base.html
+++ b/wikipendium/wiki/templates/base.html
@@ -72,7 +72,7 @@
       }
     });
     </script>
-    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     {% endif %}
 </head>
 


### PR DESCRIPTION
2.7.0 had a bug where one of the script references still pointed to the old cdn at cdn.mathjax.org.
2.7.1 fixes this.

It is not currently broken, but the moment they finally turn off the old cdn this fix will be necessary.

https://github.com/mathjax/MathJax/issues/1725

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stianjensen/wikipendium.no/451)
<!-- Reviewable:end -->
