### PR TITLE
Specify python executable on setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test:
 
 .PHONY: setup
 setup:
-	virtualenv venv
+	virtualenv venv --python=python2.7
 	cp wikipendium/settings/local.py.example wikipendium/settings/local.py
 
 .PHONY: shell


### PR DESCRIPTION
This makes the install process more explicit.

Without this the setup won't work on my machine.