### PR TITLE
Make article content not required

### DIFF
--- a/wikipendium/wiki/forms.py
+++ b/wikipendium/wiki/forms.py
@@ -13,7 +13,8 @@ class ArticleForm(ModelForm):
     choices = [('', '')] + language_list
     lang = forms.ChoiceField(label='', choices=choices)
     title = forms.CharField(label='')
-    content = forms.CharField(label='', widget=forms.Textarea())
+    content = forms.CharField(
+        label='', widget=forms.Textarea(), required=False)
 
     class Meta:
         model = ArticleContent


### PR DESCRIPTION
As of django 1.10 all required form fields get the html5 field required
[1].

Unfortunately, CodeMirror works poorly with this attribute, which makes
it now impossible to create new articles [2].

Luckily, nothing really breaks if you create an empty article, so this
little fix should make it possible to create articles again.

[1]: https://docs.djangoproject.com/en/2.1/releases/1.10/#forms
[2]: https://github.com/codemirror/CodeMirror/issues/3002

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stianjensen/wikipendium.no/456)
<!-- Reviewable:end -->
