### PR TITLE
Use patched django-dumpdb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ newrelic==2.54.0.41
 django-mailgun==0.8.0
 django-compressor==2.1
 django-taggit==0.18.0
-git+git://github.com/wikipendium/django-dumpdb.git
+git+git://github.com/wikipendium/django-dumpdb.git@16ad009#egg=django-dumpdb
 flake8==2.4.1
 flake8-quotes==0.0.1
 libsass==0.8.3


### PR DESCRIPTION
This should hopefully make the backup-to-s3 command work again (if pip
is good enough to install the correct dependency for us).

https://github.com/wikipendium/django-dumpdb/pull/1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stianjensen/wikipendium.no/457)
<!-- Reviewable:end -->
