### PR TITLE
Upgrade packages for django 1.10 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ boto==2.38.0
 newrelic==2.54.0.41
 django-mailgun==0.8.0
 django-compressor==2.1
-django-taggit==0.18.0
+django-taggit==0.22.2
 git+git://github.com/wikipendium/django-dumpdb.git@16ad009#egg=django-dumpdb
 flake8==2.4.1
 flake8-quotes==0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ git+git://github.com/wikipendium/django-dumpdb.git@16ad009#egg=django-dumpdb
 flake8==2.4.1
 flake8-quotes==0.0.1
 libsass==0.8.3
-django-haystack==2.4.0
+django-haystack==2.7.0
 Whoosh==2.7.0


### PR DESCRIPTION
Upgrade django-haystack to 2.7.0 
2.4.0 did not have official django 1.10 support, and the full text
search currently crashes, and that no longer happens with this version.

2.7.0 is also the last release to support django 1.10

---

Upgrade django-taggit to 0.22.2

This is the last version to support django 1.10

We need to migrate to django 1.11 before we can upgrade taggit further.

Currently, on django 1.10 tags don't work at all, and gives a 500 error
when clicking on a tag link. That no longer happens with this version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stianjensen/wikipendium.no/458)
<!-- Reviewable:end -->
