### PR TITLE
Remove import of url from future

### DIFF
--- a/wikipendium/wiki/templates/registration/password_reset_email.html
+++ b/wikipendium/wiki/templates/registration/password_reset_email.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load url from future %}
+{% load i18n %}
 {% autoescape off %}
 {% trans "You're receiving this e-mail because you requested a password reset" %}
 {% blocktrans %}for your user account at Wikipendium{% endblocktrans %}.


### PR DESCRIPTION
This stopped working way back in django 1.9 (django 1.9 is the future
that the import was talking about).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stianjensen/wikipendium.no/461)
<!-- Reviewable:end -->
