### PR TITLE
Utf-8-encode twitter share url parameters

### DIFF
--- a/wikipendium/wiki/views.py
+++ b/wikipendium/wiki/views.py
@@ -52,12 +52,13 @@ def _cacheable_article(request, article_content, lang='en', old=False):
     twitter_share_url = '%s%s' % (
         settings.BASE_URL, article_content.get_absolute_url())
     twitter_share_hashtags = 'wikipendium,ntnu'
-    twitter_share_intent_href = ('https://twitter.com/intent/tweet?%s' %
-                                 urllib.urlencode({
-                                     'text': twitter_share_text,
-                                     'url': twitter_share_url,
-                                     'hashtags': twitter_share_hashtags,
-                                 }))
+    twitter_share_intent_href = (
+        'https://twitter.com/intent/tweet?%s' % urllib.urlencode({
+            'text': twitter_share_text.encode('utf-8'),
+            'url': twitter_share_url.encode('utf-8'),
+            'hashtags': twitter_share_hashtags,
+        })
+    )
 
     return render(request, 'article.html', {
         'mathjax': True,


### PR DESCRIPTION
This fixes a regression from
https://github.com/stianjensen/wikipendium.no/pull/408 that affected
compendiums with æøå in their title or url.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stianjensen/wikipendium.no/462)
<!-- Reviewable:end -->
