### PR TITLE
Fix password reset template url access

### DIFF
--- a/wikipendium/wiki/templates/registration/password_reset_email.html
+++ b/wikipendium/wiki/templates/registration/password_reset_email.html
@@ -5,7 +5,7 @@
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
-{{ protocol }}://{{ domain }}{% url 'django.contrib.auth.views.password_reset_confirm' uidb64=uid token=token %}
+{{ protocol }}://{{ domain }}{% url 'auth_password_reset_confirm' uidb64=uid token=token %}
 {% endblock %}
 {% trans "Your username, in case you've forgotten:" %} {{ user.username }}
 


### PR DESCRIPTION
In django 1.10, you cannot reference urls by a string-like path anymore,
so this switches to using the name of the url, found in:
https://github.com/macropin/django-registration/blob/4e032efe8c5a491f9c699aeeb845ce411838773e/registration/auth_urls.py#L69

This fixes #459.