### PR TITLE
Explicitly render tag-like source in diff view

### DIFF
--- a/wikipendium/wiki/views.py
+++ b/wikipendium/wiki/views.py
@@ -302,8 +302,9 @@ def history_single(request, slug, lang='en', id=None):
                                  has_child, lang='en', id=None):
 
         ac.diff = diff.render_diff_as_html(
-            ac.parent.content if ac.parent else '',
-            ac.content
+            (ac.parent.content if ac.parent else '').replace(
+                '<', '&lt;').replace('>', '&gt;'),
+            ac.content.replace('<', '&lt;').replace('>', '&gt;')
         )
 
         originalArticle = article.get_newest_content(lang=lang)


### PR DESCRIPTION
`<` and `>` were removed by the html sanitizer, but really, we want to
just render those as `&lt;` and `&gt;`.

This fixes wikipendium/wikipendium.no#434 - Markdown links are invisible
in diff view.
