### PR TITLE
Add wikipendium dark mode

### DIFF
--- a/wikipendium/static/css/helium.css
+++ b/wikipendium/static/css/helium.css
@@ -2056,3 +2056,32 @@ button.close {
   border: 0;
   -webkit-appearance: none;
 }
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #121212;
+    color: #a4a4a4;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    color: #a4a4a4;
+  }
+  .button {
+    background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(1px, #000), color-stop(1px, #0b0b0b), color-stop(2px, #0b0b0b), color-stop(2px, #000), color-stop(100%, #0b0b0b)) !important;
+    background-image: -webkit-linear-gradient(top, #000 1px, #0b0b0b 1px, #0b0b0b 2px, #000 2px, #0b0b0b 100%) !important;
+    background-image: -moz-linear-gradient(top, #000 1px, #0b0b0b 1px, #000 2px, #000 2px, #0b0b0b 100%) !important;
+    background-image: -o-linear-gradient(top, #000 1px, #0b0b0b 1px, #0b0b0b 2px, #000 2px, #0b0b0b 100%) !important;
+    background-image: linear-gradient(top, #000 1px, #0b0b0b 1px, #0b0b0b 2px, #0000 2px, #0b0b0b 100%) !important;
+    -webkit-box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.08) !important;
+    -moz-box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.08) !important;
+    box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.08) !important;
+    text-shadow: 0px 1px 0px black !important;
+    color: #a4a4a4 !important;
+  }
+  .field-group .field-label {
+    color: #a4a4a4;
+  }
+  input {
+    background-color: #444;
+    color: #1a1a1a;
+  }
+}

--- a/wikipendium/static/scss/header.scss
+++ b/wikipendium/static/scss/header.scss
@@ -2,4 +2,3 @@
   margin: 0;
   padding: 0;
 }
-

--- a/wikipendium/static/scss/master.scss
+++ b/wikipendium/static/scss/master.scss
@@ -131,3 +131,11 @@ body {
     padding-top: 50px;
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  body.frontpage {
+    &:before {
+      color: #444;
+    }
+  }
+}

--- a/wikipendium/static/scss/searchbox.scss
+++ b/wikipendium/static/scss/searchbox.scss
@@ -22,3 +22,18 @@
   background: rgba(0, 204, 255, 0.5);
 }
 
+@media (prefers-color-scheme: dark) {
+  .green-bg {
+    background: rgba(0, 64, 105, 0.5);
+  }
+  #searchbox {
+    background: rgba(30, 30, 35, 0.5);
+  }
+  #suggestions .active {
+    color: #004478;
+    border: 1px solid #BDC7D8;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    color: #a4a4a4;
+  }
+}

--- a/wikipendium/wiki/static/scss/all-articles.scss
+++ b/wikipendium/wiki/static/scss/all-articles.scss
@@ -65,3 +65,31 @@
     }
   }
 }
+
+@media (prefers-color-scheme: dark) {
+    .article-all-list {
+      li {
+        border: 1px solid #ccc;
+        color: #069;
+        background-color: rgba(0, 0, 0, 0.2);
+        &.active a {
+          color: #069;
+        }
+      }
+      .no-found {
+        color: #a4a4a4;
+      }
+      .date {
+        color: #a4a4a4;
+      }
+      .active .date {
+        color: #a4a4a4;
+      }
+      .highlight {
+        background: rgba(0, 58, 104, 0.2);
+      }
+      .active .highlight {
+        background: #014;
+      }
+    }
+}

--- a/wikipendium/wiki/static/scss/article.scss
+++ b/wikipendium/wiki/static/scss/article.scss
@@ -338,3 +338,41 @@ ul.no-list {
   list-style-type: none;
   padding: 0;
 }
+
+@media (prefers-color-scheme: dark) {
+  .toc {
+    background: #1a1a1a;
+    border-right: 1px solid #111;
+    a {
+      &.hilight {
+        color: #a4a4a4;
+        background: #294854;
+        border-radius: 4px;
+      }
+    }
+  }
+  .article-wrapper {
+    .margin-note {
+      position: relative;
+      float: right;
+      border-left: 3px solid #023;
+      background: #1a1a1a;
+    }
+  }
+  #toggle-toc {
+    color: #a4a4a4;
+    background: #294854;
+    border: 1px solid #0a1d24,
+  }
+  code {
+    background: #1a1a1a;
+    border: 1px solid #111111;
+    display: inline;
+    padding: 5px;
+  }
+  body {
+    &.fixed-header .header-wrapper {
+      background: rgba(12, 12, 12, 0.5);
+    }
+  }
+}

--- a/wikipendium/wiki/static/scss/codemirror.scss
+++ b/wikipendium/wiki/static/scss/codemirror.scss
@@ -220,3 +220,29 @@ body.editor #content {
     }
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  body.editor .CodeMirror {
+    border: 1px solid #111;
+  }
+  #help-container {
+    border: 1px solid #111;
+    background: #1a1a1a;
+  }
+  #tab-close-button {
+    color: #a4a4a4;
+    background: #121212;
+    &:hover {
+      background: #111;
+    }
+  }
+  #preview-container {
+    background: #111;
+    border: 1px solid #121212;
+
+    #preview-header {
+      border-bottom: 1px solid #111;
+      background: #1a1a1a;
+    }
+  }
+}


### PR DESCRIPTION
Now we have a dark mode that we can iterate on. It's far from perfect,
but I think it's usable, and a in a decent state for us to merge.

This fixes wikipendium/wikipendium.no#466.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/1488921/138961527-c5e9ad72-2763-40bf-a870-ba8a3e0f177c.png">
